### PR TITLE
Use ConfigCache instead of symfony/cache

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 | Q             | A
 | ------------- | --------------------------------------------------------------------- |
-| Bug fix?      | yes/no                                                                |
+| BC breaks?    | yes/no                                                                |
 | New feature?  | yes/no <!-- don't forget to update CHANGELOG.md -->                   |
 | Improvement?  | yes/no <!-- improves an existing feature, not adding a new one -->    |
-| BC breaks?    | yes/no                                                                |
+| Bug fix?      | yes/no                                                                |
 | Deprecations? | yes/no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
 | Docs PR       | **missing** <!-- insert URL here -->                                  |
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /.php_cs.cache
 /.phpunit.result.cache
 /composer.lock
+/studio.json
 /vendor
+/vendor-bin/*/composer.lock
+/vendor-bin/*/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,22 @@ git:
 
 php:
     - "7.2"
-    - "7.3"
+    - "7.4"
 
 before_install:
     - composer require php-coveralls/php-coveralls --prefer-dist --no-interaction --no-progress
-    - composer global require localheinz/composer-normalize --prefer-dist --no-interaction --no-progress
 
 install:
     - composer install --prefer-dist --no-interaction --no-progress
+    - composer global require ergebnis/composer-normalize bamarni/composer-bin-plugin --no-interaction --prefer-dist --no-progress --no-suggest --no-suggest
+    - composer bin all install --no-interaction --prefer-dist --no-progress --no-suggest
     - mkdir -p build/logs
 
 script:
     - composer normalize --indent-size 4 --indent-style space --dry-run
-    - php vendor/bin/php-cs-fixer.phar fix --diff --config vendor/becklyn/php-cs/.php_cs.dist --dry-run --no-interaction
-    #- php vendor/bin/phpstan analyse -l 4 --memory-limit 4G --ansi -c phpstan.neon . --no-interaction --no-progress
-    - ./vendor/bin/simple-phpunit -c phpunit.xml --coverage-clover build/logs/clover.xml
+    - ./vendor/bin/php-cs-fixer fix --diff --config vendor-bin/test/vendor/becklyn/php-cs/.php_cs.dist --dry-run --no-interaction
+    - ./vendor/bin/phpstan analyse --memory-limit 4G --ansi -c vendor-bin/test/vendor/becklyn/php-cs/phpstan/lib.neon src --no-interaction --no-progress
+    - ./vendor/bin/simple-phpunit -c phpunit.xml --coverage-clover build/logs/clover.xml --testdox
 
 after_script:
     - travis_retry php vendor/bin/php-coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.2
+=====
+
+*   (improvement) Use `ConfigCache` instead of `symfony/cache`.
+
+
 1.0.1
 =====
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =====
 
 *   (improvement) Use `ConfigCache` instead of `symfony/cache`.
+*   (improvement) Remove obsolete locale (the parameter was unused so far).
 
 
 1.0.1

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "symfony/cache-contracts": "^1.1 || ^2.0",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",
         "symfony/framework-bundle": "^4.3 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,20 +23,15 @@
         "twig/twig": "^2.11 || ^3.0"
     },
     "require-dev": {
-        "becklyn/php-cs": "^3.0.1",
-        "roave/security-advisories": "dev-master",
-        "tm/tooly-composer-script": "^1.4"
+        "roave/security-advisories": "dev-master"
     },
     "config": {
         "sort-packages": true
     },
     "extra": {
-        "tools": {
-            "php-cs-fixer": {
-                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.0/php-cs-fixer.phar",
-                "sign-url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.0/php-cs-fixer.phar.asc",
-                "only-dev": true
-            }
+        "branch-alias": {
+            "dev-master": "2.x-dev",
+            "dev-next": "2.x-dev"
         }
     },
     "autoload": {
@@ -48,9 +43,5 @@
         "psr-4": {
             "Tests\\Becklyn\\JavaScriptRouting\\": "tests/"
         }
-    },
-    "scripts": {
-        "post-install-cmd": "Tooly\\ScriptHandler::installPharTools",
-        "post-update-cmd": "Tooly\\ScriptHandler::installPharTools"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev",
-            "dev-next": "2.x-dev"
+            "dev-master": "1.x-dev",
+            "dev-next": "1.x-dev"
         }
     },
     "autoload": {

--- a/src/Controller/DumpRoutesController.php
+++ b/src/Controller/DumpRoutesController.php
@@ -16,12 +16,11 @@ class DumpRoutesController extends AbstractController
     public function dump (
         RoutesExtractor $extractor,
         ParameterBagInterface $parameters,
-        Request $request,
-        string $locale
+        Request $request
     ) : Response
     {
         $isDebug = $parameters->get("kernel.debug");
-        $collection = $extractor->extract($locale, !$isDebug);
+        $collection = $extractor->extract();
         $json = \addslashes($collection->getJson());
 
         $response = new JsonResponse(

--- a/src/Extractor/RoutesExtractor.php
+++ b/src/Extractor/RoutesExtractor.php
@@ -44,7 +44,7 @@ class RoutesExtractor
     {
         $cache = $this->getCache()->cache(
             "{$this->cacheDir}/" . self::CACHE_PATH,
-            function (ConfigCacheInterface $cache)
+            function (ConfigCacheInterface $cache) : void
             {
                 $cache->write(
                     '<?php return ' . \var_export($this->extractRoutes(), true) . ';',

--- a/src/Resources/config/routes.yaml
+++ b/src/Resources/config/routes.yaml
@@ -1,6 +1,4 @@
 becklyn_javascript_routing.dump:
-    path: /dump/{locale}
+    path: /dump
     controller: 'Becklyn\JavaScriptRouting\Controller\DumpRoutesController::dump'
     methods: [GET]
-    requirements:
-        locale: '[a-z]+([-_][a-zA-Z]+)?'

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -2,6 +2,9 @@ services:
     _defaults:
         autoconfigure: true
         autowire: true
+        bind:
+            $isDebug: '%kernel.debug%'
+            $cacheDir: '%kernel.cache_dir%'
 
     Becklyn\JavaScriptRouting\:
         resource: '../../*'

--- a/src/Resources/views/init.html.twig
+++ b/src/Resources/views/init.html.twig
@@ -3,4 +3,4 @@
         window.RouterInit = {data: {}, init: function (data) { this.data = data; }};
     })(window);
 </script>
-<script defer src="{{ url("becklyn_javascript_routing.dump", {locale: locale}) }}"></script>
+<script defer src="{{ url("becklyn_javascript_routing.dump") }}"></script>

--- a/src/Twig/JavaScriptRoutesTwigExtension.php
+++ b/src/Twig/JavaScriptRoutesTwigExtension.php
@@ -35,23 +35,9 @@ class JavaScriptRoutesTwigExtension extends AbstractExtension implements Service
     /**
      *
      */
-    public function renderInit (?string $locale = null) : string
+    public function renderInit () : string
     {
-        if (null === $locale)
-        {
-            $request = $this->requestStack->getMasterRequest();
-
-            if (null === $request)
-            {
-                return "<-- Can't embed, because no locale given -->";
-            }
-
-            $locale = $request->getLocale();
-        }
-
-        return $this->locator->get(Environment::class)->render("@BecklynJavaScriptRouting/init.html.twig", [
-            "locale" => $locale,
-        ]);
+        return $this->locator->get(Environment::class)->render("@BecklynJavaScriptRouting/init.html.twig");
     }
 
 

--- a/vendor-bin/test/composer.json
+++ b/vendor-bin/test/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "becklyn/php-cs": "^3.0"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->

The big improvement in this PR is that the config cache can be cached in `debug` as well. With this new caching mechanism the generation of the routes got faster from 

before: 20ms
after: 3ms

So it got faster by a factor of 10.

The main reason is that the `ConfigCache` keeps automatically track of all routing files in the system and detects if a file has changed. It only regenerates if anything has changed in debug and regenerates never in prod (just like the normal cache).
That is the same system the core of Symfony is using internally for nearly everything (like for dumping the router).